### PR TITLE
Bug fix: Planets and Signs

### DIFF
--- a/src/dialogs/PlanetSignDisplayPanel.cpp
+++ b/src/dialogs/PlanetSignDisplayPanel.cpp
@@ -47,7 +47,8 @@ extern Config *config;
 ******************************************************/
 PlanetSignDisplayPanel::PlanetSignDisplayPanel( wxWindow* parent ) : ConfigPanel( parent )
 {
-		cfg = new WriterConfig( *config->writer );
+		cfg = new WriterConfig;
+        config2model();
 		props = new ChartProperties;
 		horoscope = new Horoscope;
 
@@ -117,7 +118,7 @@ PlanetSignDisplayPanel::~PlanetSignDisplayPanel()
 ******************************************************/
 void PlanetSignDisplayPanel::config2model()
 {
-	*cfg = WriterConfig( *config->writer );
+	*cfg = *config->writer;
 }
 
 /*****************************************************
@@ -211,6 +212,7 @@ void PlanetSignDisplayPanel::updateUi()
 	check_vedic_sign_names->Enable(! vpositions && ! ssymbols );
 	choice_capricorn->Enable( ! vpositions && ssymbols );
 
+    model2config();
 	writeTextContents();
 }
 


### PR DESCRIPTION
As requested by Robin for Maitreya9.

Fixed bug in Configuration/User Interface/Planets and Signs.

2 WriterConfig objects are used and they were not in sync which caused this issue